### PR TITLE
Add explicity dependecy on systemd

### DIFF
--- a/app-emulation/snapd/snapd-2.40-r1.ebuild
+++ b/app-emulation/snapd/snapd-2.40-r1.ebuild
@@ -38,6 +38,7 @@ EGO_PN="github.com/snapcore/${PN}"
 RDEPEND="!sys-apps/snap-confine
 	sys-libs/libseccomp[static-libs]
 	sys-apps/apparmor
+	sys-apps/systemd
 	dev-libs/glib
 	sys-fs/squashfs-tools:*
 	sec-policy/apparmor-profiles"


### PR DESCRIPTION
Currently, this ebuild will compile on any gentoo system. However, this is useless without all 
the services. So until there is an OpenRC port, this should not compile on systems without Systemd.