### PR TITLE
Enable nvidia biarch compile option

### DIFF
--- a/app-emulation/snapd/snapd-2.44.5.ebuild
+++ b/app-emulation/snapd/snapd-2.44.5.ebuild
@@ -96,7 +96,8 @@ EOF
 		--libexecdir="/usr/$(get_libdir)/snapd" \
 		--enable-maintainer-mode \
 		--disable-silent-rules \
-		--enable-apparmor
+		--enable-apparmor \
+		--enable-nvidia-biarch
 }
 
 src_compile() {

--- a/app-emulation/snapd/snapd-2.45.3.1.ebuild
+++ b/app-emulation/snapd/snapd-2.45.3.1.ebuild
@@ -96,7 +96,8 @@ EOF
 		--libexecdir="/usr/$(get_libdir)/snapd" \
 		--enable-maintainer-mode \
 		--disable-silent-rules \
-		--enable-apparmor
+		--enable-apparmor \
+		--enable-nvidia-biarch
 }
 
 src_compile() {

--- a/app-emulation/snapd/snapd-9999.ebuild
+++ b/app-emulation/snapd/snapd-9999.ebuild
@@ -95,7 +95,8 @@ EOF
 		--libexecdir="/usr/$(get_libdir)/snapd" \
 		--enable-maintainer-mode \
 		--disable-silent-rules \
-		--enable-apparmor
+		--enable-apparmor \
+		--enable-nvidia-biarch
 }
 
 src_compile() {


### PR DESCRIPTION
Without this option, snap won't work on a machine with nvidia graphic card.

Signed-off-by: layman <layman@localhost>